### PR TITLE
chore(wire-desktop): Remove addressbook permission on macOS

### DIFF
--- a/wire-desktop/content/macos/entitlements/parent.plist
+++ b/wire-desktop/content/macos/entitlements/parent.plist
@@ -14,8 +14,6 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-write</key>
     <true/>
-    <key>com.apple.security.personal-information.addressbook</key>
-    <true/>
     <key>com.apple.security.application-groups</key>
     <string>EDF3JCE8BC.com.wearezeta.zclient.mac</string>
   </dict>


### PR DESCRIPTION
Since we are [not using the addressbook anymore](https://github.com/wireapp/wire-desktop/pull/3058), we can remove the permission on macOS.