### PR TITLE
refactor(webapp): Remove slug from legal hold support URL

### DIFF
--- a/wire-webapp/.env.defaults
+++ b/wire-webapp/.env.defaults
@@ -150,7 +150,7 @@ URL_SUPPORT_EMAIL_EXISTS="https://support.wire.com/hc/articles/115004082129"
 
 URL_SUPPORT_HISTORY="https://support.wire.com/hc/articles/207834645"
 
-URL_SUPPORT_LEGAL_HOLD_BLOCK="https://support.wire.com/hc/articles/360002018278-What-is-legal-hold-"
+URL_SUPPORT_LEGAL_HOLD_BLOCK="https://support.wire.com/hc/articles/360002018278"
 
 URL_SUPPORT_MICROPHONE_ACCESS_DENIED="https://support.wire.com/hc/articles/202590081"
 


### PR DESCRIPTION
URLs are more stable when removing the slug and just keeping the ID. In this case the URL does not break when the title of the post is changed.