### PR TITLE
chore: rename subpath to url_path

### DIFF
--- a/wire-webapp/.env.defaults
+++ b/wire-webapp/.env.defaults
@@ -161,13 +161,13 @@ URL_TERMS_OF_USE_TEAMS="https://wire.com/legal/#teams"
 URL_WEBSITE_BASE="https://wire.com"
 
 # Sets paths to append to a base URL
-URL_SUBPATH_CREATE_TEAM="register/email"
+URL_PATH_CREATE_TEAM="/register/email"
 
-URL_SUBPATH_MANAGE_SERVICES="services/"
+URL_PATH_MANAGE_SERVICES="/services/"
 
-URL_SUBPATH_MANAGE_TEAM="login/"
+URL_PATH_MANAGE_TEAM="/login/"
 
-URL_SUBPATH_PASSWORD_RESET="/forgot/"
+URL_PATH_PASSWORD_RESET="/forgot/"
 
 # Sets Support URLs to specific pages
 URL_SUPPORT_INDEX="https://support.wire.com/"


### PR DESCRIPTION
### Description

- rename `SUBPATH` to just `PATH` (see https://github.com/wireapp/wire-webapp/pull/16774/files#r1482706106)
- add missing `/` to some of those paths 