### PR TITLE
feat: add tagmanager url to the TM settings

### DIFF
--- a/wire-team-settings/.env.defaults
+++ b/wire-team-settings/.env.defaults
@@ -186,7 +186,7 @@ CSP_EXTRA_MEDIA_SRC=""
 CSP_EXTRA_OBJECT_SRC=""
 
 # Adds additional CSP script-src entries.
-CSP_EXTRA_SCRIPT_SRC="https://*.wire.com, https://wire.innocraft.cloud, https://js.stripe.com, https://app-lon08.marketo.com"
+CSP_EXTRA_SCRIPT_SRC="https://*.wire.com, https://wire.innocraft.cloud, https://js.stripe.com, https://app-lon08.marketo.com, https://www.googletagmanager.com"
 
 # Adds additional CSP style-src entries.
 CSP_EXTRA_STYLE_SRC="https://app-lon08.marketo.com"


### PR DESCRIPTION
We need to add the google tag manager URL to our CSP settings for that feature to be usable.