### PR TITLE
fix: add e2ei support links

### DIFF
--- a/wire-webapp/.env.defaults
+++ b/wire-webapp/.env.defaults
@@ -234,6 +234,10 @@ URL_SUPPORT_REMOVE_TEAM_MEMBER="https://support.wire.com/hc/articles/11500421948
 
 URL_SUPPORT_E2E_ENCRYPTION="https://support.wire.com/hc/articles/10898523878173"
 
+URL_SUPPORT_E2EI_VERIFICATION="https://support.wire.com/hc/articles/9211300150685"
+
+URL_SUPPORT_E2EI_VERIFICATION_CERTIFICATE="https://support.wire.com/hc/articles/9211300150685"
+
 URL_WHATS_NEW="https://medium.com/wire-news/webapp-updates/home"
 
 # Content Security Policy


### PR DESCRIPTION
#### Description

add support links for
- the identity provider certificate modals
- system message for change of verification status in a conversation (verified, degraded, etc)

both set to the same support page https://support.wire.com/hc/en-us/articles/9211300150685-ID-Shield until a secific page for the system message is created